### PR TITLE
fix(broker): allow term-llm-reviewer image tag in build policy

### DIFF
--- a/crates/secure-container-runtime/src/broker.rs
+++ b/crates/secure-container-runtime/src/broker.rs
@@ -876,9 +876,12 @@ impl ContainerBroker {
         use bollard::image::BuildImageOptions;
 
         // Verify policy allows building this tag
-        // For now, only allow term-compiler images or specific tags
+        // Allow term-compiler, term-llm-reviewer, and ghcr.io images
         // This is a basic check, could be expanded in SecurityPolicy
-        if !tag.starts_with("term-compiler:") && !tag.starts_with("ghcr.io/") {
+        if !tag.starts_with("term-compiler:")
+            && !tag.starts_with("term-llm-reviewer:")
+            && !tag.starts_with("ghcr.io/")
+        {
             let err = format!("Image tag not allowed: {}", tag);
             self.audit(
                 AuditAction::ImageBuild,


### PR DESCRIPTION
## Summary

Adds `term-llm-reviewer:` prefix to the allowed image tags list in the container broker's build policy.

## Problem

The LLM reviewer image build was failing with:
```
Policy violation: Image tag not allowed: term-llm-reviewer:latest
```

## Solution

Updated the image tag whitelist in `broker.rs` to allow:
- `term-compiler:` (existing)
- `term-llm-reviewer:` (new)
- `ghcr.io/` (existing)

## Testing

- Code compiles: `cargo check -p secure-container-runtime` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image build policy now supports an additional container image tag prefix, expanding validation coverage for build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->