### PR TITLE
fix(scripts): allow live prism Lium attestation e2e under PrismSettings

### DIFF
--- a/scripts/prism_lium_attestation_e2e.py
+++ b/scripts/prism_lium_attestation_e2e.py
@@ -470,21 +470,37 @@ async def _ingest(
         "".join(_SHARD.format(i=i) for i in range(64)), encoding="utf-8"
     )
     db_path = tmp / f"{work_unit_id_marker}.sqlite3"
-    settings = PrismSettings(
-        database_url=f"sqlite+aiosqlite:///{db_path}",
-        shared_token="e2e-secret",
-        allow_insecure_signatures=True,
-        execution_backend="base_gpu",
-        docker_enabled=True,
-        docker_backend="broker",
-        docker_broker_url="http://base-docker-broker:8082",
-        docker_broker_token="secret",
-        sequence_length=16,
-        plagiarism_enabled=False,
-        distributed_contract_policy="off",
-        base_eval_artifact_root=tmp / "artifacts",
-        worker_plane=WorkerPlaneConfig(enabled=True, signing_key=WORKER_KEY),
-    )
+    # Harness-only env keys (PRISM_MISSION_CREDS, PRISM_ATTEST_E2E_TMP, …) are not
+    # PrismSettings fields. PrismSettings forbids unknown PRISM_* keys, so park them
+    # for the duration of settings construction + app init.
+    _harness_prism_env = {
+        k: os.environ.pop(k)
+        for k in list(os.environ)
+        if k.startswith("PRISM_")
+        and k
+        in {
+            "PRISM_MISSION_CREDS",
+            "PRISM_ATTEST_E2E_TMP",
+        }
+    }
+    try:
+        settings = PrismSettings(
+            database_url=f"sqlite+aiosqlite:///{db_path}",
+            shared_token="e2e-secret",
+            allow_insecure_signatures=True,
+            execution_backend="base_gpu",
+            docker_enabled=True,
+            docker_backend="broker",
+            docker_broker_url="http://base-docker-broker:8082",
+            docker_broker_token="secret",
+            sequence_length=16,
+            plagiarism_enabled=False,
+            distributed_contract_policy="off",
+            base_eval_artifact_root=tmp / "artifacts",
+            worker_plane=WorkerPlaneConfig(enabled=True, signing_key=WORKER_KEY),
+        )
+    finally:
+        os.environ.update(_harness_prism_env)
     # Patch docker executor the same way unit tests do.
     import prism_challenge.evaluator.container as container_mod
 


### PR DESCRIPTION
## Summary
Unblocks the live Prism×Lium attestation E2E harness after a successful real pod cycle.

`PrismSettings` forbids unknown `PRISM_*` env keys. The harness uses `PRISM_MISSION_CREDS` / `PRISM_ATTEST_E2E_TMP`, which aborted ingest with `Unknown Prism configuration key` even though Lium rent + constation runner had already succeeded.

## Change
Park harness-only `PRISM_*` keys while constructing `PrismSettings`, then restore them.

## Live proof (this environment)
| Path | REAL_LIUM | Result |
|------|-----------|--------|
| honest | true | `constation_ok=True`, `effective_tier=1`, `score_written=True`, `final_score≈0.76` |
| adversarial (mid-run sidecar swap) | true | `constation_ok=False` (`corroboration_mismatch`), `score_written=False` |

Evidence: `.omo/notepads/wire-constation-production/evidence/checkbox-27-live/`

## Test plan
- [x] Live honest + adversarial against `https://lium.io/api` (pods terminated in finally)
- [ ] CI green on this PR