### PR TITLE
chore(release): bump version to 3.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "base"
-version = "3.1.2"
+version = "3.2.0"
 description = "Multi-challenge Bittensor subnet validator platform"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/base/challenge_sdk/release_manifest.json
+++ b/src/base/challenge_sdk/release_manifest.json
@@ -1,9 +1,9 @@
 {
   "distribution_name": "base",
-  "artifact_version": "3.1.2",
+  "artifact_version": "3.2.0",
   "sdk_contract_version": "1.0.0",
   "api_version": "1.0",
-  "release_id": "v3.1.2",
+  "release_id": "v3.2.0",
   "public_imports": {
     "base.challenge_sdk.config": [
       "ChallengeSettings",

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ wheels = [
 
 [[package]]
 name = "base"
-version = "3.1.2"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump Base distribution identity from **3.1.2** → **3.2.0** so a `v3.2.0` tag can cut a wheel that includes the constation/attestation modules already on `main` (#41, #42).
- Latest published release **v3.1.2 (2026-07-12)** predates that work; consumers (e.g. prism) currently pin a git SHA and break hermetic Docker installs that lack `git`.

## Changes
- `pyproject.toml`: `[project] version = "3.2.0"`
- `src/base/challenge_sdk/release_manifest.json`: `artifact_version = "3.2.0"`, `release_id = "v3.2.0"`
- `uv.lock`: workspace package `base` version `3.2.0` (required — `uv sync --locked` / monorepo-workspace + github-release jobs fail without it; one-line identity bump only)

No functional code, dependency, or migration changes.

## Why these fields move together
`.github/workflows/ci.yml` `github-release` asserts on tag `v*`:

```text
project["project"]["version"] == expected
manifest["artifact_version"] == expected
manifest["release_id"] == f"v{expected}"
```

## Test plan
- [x] Release-job identity assert locally (`3.2.0` / `v3.2.0` / loaded `ARTIFACT_VERSION`)
- [x] `uv sync --locked --extra dev --extra master`
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run mypy src tests`
- [x] monorepo-workspace pytest subset (26 passed)
- [x] versioning/release/roles/health contracts (21 passed)
- [x] production-policy subset (89 passed)
- [x] full `pytest --cov=base --cov-fail-under=80` → 2308 passed, 83.66% cov
- [ ] CI green on this PR head

## CI
- Waiting for required checks to go green on this head SHA.

## Notes
- **Do not merge from this PR automation.** Tagging `v3.2.0` is a separate human step after merge.
- Trust model unchanged: **tamper-evidence, not tamper-prevention**. No TEE claims.
- Other hardcoded `3.1.2` strings left intentionally (fixture samples, prism image pins, prism Dockerfile wheel URL assertions). They are not the Base distribution identity and must not move blindly with this bump.
- Original dirty checkout on `feat/agent-challenge-eval-wire-ghcr` was left untouched via a separate git worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project release version from 3.1.2 to 3.2.0.
  * Updated release metadata to reflect version 3.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->