### PR TITLE
fix(master): load per-challenge embed.env into isolated child env

### DIFF
--- a/docker/master-entrypoint.sh
+++ b/docker/master-entrypoint.sh
@@ -32,6 +32,11 @@ AC_PORT="${BASE_MASTER_AC_PORT:-18081}"
 PRISM_DATA_DIR="${BASE_MASTER_PRISM_DATA_DIR:-/var/lib/base/challenges/prism}"
 AC_DATA_DIR="${BASE_MASTER_AC_DATA_DIR:-/var/lib/base/challenges/agent-challenge}"
 
+# Operator-supplied overrides merged into the isolated child environments.
+# Defaults live beside each challenge's data so they survive image rebuilds.
+PRISM_ENV_FILE="${BASE_MASTER_PRISM_ENV_FILE:-${PRISM_DATA_DIR}/embed.env}"
+AC_ENV_FILE="${BASE_MASTER_AC_ENV_FILE:-${AC_DATA_DIR}/embed.env}"
+
 # Child PIDs for cleanup (proxy is usually the last foreground wait target).
 CHILD_PIDS=()
 
@@ -54,6 +59,80 @@ embed_truthy() {
     1|true|TRUE|yes|YES|on|ON) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# Merge operator-supplied KEY=VALUE lines into an isolated child environment.
+#
+# Embedded challenges start under `env -i` so Prism never sees CHALLENGE_* and
+# agent-challenge never sees PRISM_*. That isolation is deliberate, but it also
+# dropped every operator setting -- including the Phala attestation switches
+# (CHALLENGE_PHALA_ATTESTATION_ENABLED / CHALLENGE_ATTESTED_REVIEW_ENABLED) and
+# the eval/review app identities -- because the built-in list was hardcoded with
+# no extension point. This is that extension point: allowlisted keys from the
+# file are appended AFTER the defaults, so the file wins.
+#
+# Values are never logged (secrets hygiene); only key names are.
+load_challenge_env_file() {
+  local -n _target_env="$1"
+  local env_file="$2"
+  shift 2
+  local -a allowed_prefixes=("$@")
+
+  if [[ -z "${env_file}" ]]; then
+    return 0
+  fi
+  if [[ ! -e "${env_file}" ]]; then
+    log "no env file at ${env_file}; using built-in defaults only"
+    return 0
+  fi
+  if [[ ! -r "${env_file}" ]]; then
+    log "ERROR: env file ${env_file} exists but is not readable"
+    return 1
+  fi
+
+  local line key value prefix allowed
+  local -a accepted=()
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    # Trim surrounding whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    if [[ -z "${line}" || "${line}" == '#'* ]]; then
+      continue
+    fi
+    line="${line#export }"
+    if [[ "${line}" != *=* ]]; then
+      continue
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    if [[ ! "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      continue
+    fi
+    # Strip one layer of matching quotes around the value.
+    if [[ "${value}" == \"*\" && "${#value}" -ge 2 ]]; then
+      value="${value:1:${#value}-2}"
+    elif [[ "${value}" == \'*\' && "${#value}" -ge 2 ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+    allowed=0
+    for prefix in "${allowed_prefixes[@]}"; do
+      if [[ "${key}" == "${prefix}"* ]]; then
+        allowed=1
+        break
+      fi
+    done
+    if (( ! allowed )); then
+      continue
+    fi
+    _target_env+=("${key}=${value}")
+    accepted+=("${key}")
+  done < "${env_file}"
+
+  if (( ${#accepted[@]} )); then
+    log "loaded ${#accepted[@]} override(s) from ${env_file}: ${accepted[*]}"
+  else
+    log "no applicable overrides in ${env_file}"
+  fi
 }
 
 prepare_challenge_dirs() {
@@ -154,6 +233,13 @@ start_embedded_challenges() {
   if [[ -n "${py_path}" ]]; then
     ac_env+=("PYTHONPATH=${py_path}")
   fi
+
+  # Operator overrides win over the defaults above. Prefixes stay disjoint per
+  # challenge so the env -i isolation is preserved.
+  load_challenge_env_file prism_env "${PRISM_ENV_FILE}" \
+    PRISM_ PHALA_ DSTACK_ OPENROUTER_API_KEY
+  load_challenge_env_file ac_env "${AC_ENV_FILE}" \
+    CHALLENGE_ BASE_CHALLENGE_ PHALA_ DSTACK_ OPENROUTER_API_KEY
 
   log "starting embedded prism on ${PRISM_HOST}:${PRISM_PORT}"
   # env -i: isolate prefixes so Prism never sees CHALLENGE_* and AC never sees

--- a/tests/unit/test_master_embed_env_file.py
+++ b/tests/unit/test_master_embed_env_file.py
@@ -1,0 +1,172 @@
+"""Embedded challenge env-file contract for the master supervisor.
+
+``docker/master-entrypoint.sh`` launches each embedded challenge under
+``env -i`` so Prism never inherits ``CHALLENGE_*`` and agent-challenge never
+inherits ``PRISM_*``. That isolation is deliberate, but it also dropped every
+operator-supplied setting -- notably the Phala attestation switches
+(``CHALLENGE_PHALA_ATTESTATION_ENABLED``, ``CHALLENGE_ATTESTED_REVIEW_ENABLED``)
+and ``PHALA_CLOUD_API_KEY`` -- because the allowlist was hardcoded with no
+extension point.
+
+These tests lock the supported extension point: a per-challenge env file whose
+keys are merged into the isolated child environment, without breaking
+cross-challenge isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker/master-entrypoint.sh"
+
+FAKE_UVICORN = """#!/usr/bin/env bash
+# Dump the isolated child environment so the test can assert on it.
+# The dump path is baked in: `env -i` strips DUMP_DIR from the child env.
+target="unknown"
+for arg in "$@"; do
+  case "${arg}" in
+    prism_challenge.app:app) target="prism" ;;
+    agent_challenge.app:app) target="ac" ;;
+  esac
+done
+env > "__DUMP_DIR__/${target}.env"
+"""
+
+FAKE_PYTHON = """#!/usr/bin/env bash
+exit 0
+"""
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_entrypoint(tmp_path: Path, ac_env_file_body: str | None) -> dict[str, str]:
+    """Run the entrypoint with stubbed uvicorn/python; return child env dumps."""
+
+    bin_dir = tmp_path / "bin"
+    dump_dir = tmp_path / "dump"
+    ac_dir = tmp_path / "ac"
+    prism_dir = tmp_path / "prism"
+    for directory in (bin_dir, dump_dir, ac_dir, prism_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    _write_exec(
+        bin_dir / "uvicorn", FAKE_UVICORN.replace("__DUMP_DIR__", str(dump_dir))
+    )
+    _write_exec(bin_dir / "python", FAKE_PYTHON)
+
+    token_file = tmp_path / "shared_token"
+    token_file.write_text("test-token", encoding="utf-8")
+
+    if ac_env_file_body is not None:
+        (ac_dir / "embed.env").write_text(ac_env_file_body, encoding="utf-8")
+
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": str(tmp_path),
+        "DUMP_DIR": str(dump_dir),
+        "BASE_MASTER_AC_DATA_DIR": str(ac_dir),
+        "BASE_MASTER_PRISM_DATA_DIR": str(prism_dir),
+        "PRISM_SHARED_TOKEN_FILE": str(token_file),
+        "CHALLENGE_SHARED_TOKEN_FILE": str(token_file),
+    }
+
+    subprocess.run(
+        ["bash", str(ENTRYPOINT), "/bin/true"],
+        env=env,
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+
+    dumps: dict[str, str] = {}
+    for name in ("ac", "prism"):
+        dump = dump_dir / f"{name}.env"
+        dumps[name] = dump.read_text(encoding="utf-8") if dump.is_file() else ""
+    return dumps
+
+
+def test_ac_env_file_supplies_phala_settings_to_isolated_child(tmp_path: Path) -> None:
+    """Operator embed.env must reach the agent-challenge child under env -i."""
+
+    dumps = _run_entrypoint(
+        tmp_path,
+        "\n".join(
+            [
+                "# durable AC embed overrides",
+                "CHALLENGE_PHALA_ATTESTATION_ENABLED=true",
+                "CHALLENGE_ATTESTED_REVIEW_ENABLED=true",
+                "PHALA_CLOUD_API_KEY=phala-secret",
+                "BASE_CHALLENGE_SLUG=agent-challenge",
+                "",
+            ]
+        ),
+    )
+
+    ac_env = dumps["ac"]
+    assert "CHALLENGE_PHALA_ATTESTATION_ENABLED=true" in ac_env
+    assert "CHALLENGE_ATTESTED_REVIEW_ENABLED=true" in ac_env
+    assert "PHALA_CLOUD_API_KEY=phala-secret" in ac_env
+    assert "BASE_CHALLENGE_SLUG=agent-challenge" in ac_env
+
+
+def test_ac_env_file_does_not_leak_into_prism_child(tmp_path: Path) -> None:
+    """Cross-challenge isolation must survive the env-file merge."""
+
+    dumps = _run_entrypoint(
+        tmp_path,
+        "CHALLENGE_PHALA_ATTESTATION_ENABLED=true\nPHALA_CLOUD_API_KEY=phala-secret\n",
+    )
+
+    prism_env = dumps["prism"]
+    assert "CHALLENGE_PHALA_ATTESTATION_ENABLED" not in prism_env
+    assert "PHALA_CLOUD_API_KEY" not in prism_env
+
+
+def test_ac_env_file_overrides_builtin_default(tmp_path: Path) -> None:
+    """File-provided values win over the hardcoded defaults."""
+
+    dumps = _run_entrypoint(tmp_path, "CHALLENGE_DOCKER_ENABLED=true\n")
+
+    assert "CHALLENGE_DOCKER_ENABLED=true" in dumps["ac"]
+    assert "CHALLENGE_DOCKER_ENABLED=false" not in dumps["ac"]
+
+
+def test_missing_env_file_is_not_fatal(tmp_path: Path) -> None:
+    """Absent embed.env keeps the previous behaviour (defaults only)."""
+
+    dumps = _run_entrypoint(tmp_path, None)
+
+    assert "CHALLENGE_DOCKER_ENABLED=false" in dumps["ac"]
+    assert "PHALA_CLOUD_API_KEY" not in dumps["ac"]
+
+
+def test_env_file_ignores_comments_blanks_and_malformed_keys(tmp_path: Path) -> None:
+    """Only well-formed KEY=VALUE lines with allowed prefixes are exported."""
+
+    dumps = _run_entrypoint(
+        tmp_path,
+        "\n".join(
+            [
+                "# comment",
+                "",
+                "   ",
+                "export CHALLENGE_EVAL_MAX_ATTEMPTS=3",
+                "not-a-valid-key=nope",
+                "RANDOM_UNRELATED=leak",
+                "CHALLENGE_EVAL_APP_IDENTITY=app-id",
+                "",
+            ]
+        ),
+    )
+
+    ac_env = dumps["ac"]
+    assert "CHALLENGE_EVAL_MAX_ATTEMPTS=3" in ac_env
+    assert "CHALLENGE_EVAL_APP_IDENTITY=app-id" in ac_env
+    assert "RANDOM_UNRELATED" not in ac_env
+    assert "not-a-valid-key" not in ac_env


### PR DESCRIPTION
## Summary
- Embedded challenges start under `env -i`, and the passed-through variable list was **hardcoded with no extension point**, so every operator-supplied setting was silently dropped.
- Agent Challenge therefore booted with `phala_attestation_enabled=False` and `attested_review_enabled=False` **even though the operator env file enabled both**.
- Adds the supported extension point: a per-challenge `embed.env` merged into the isolated child environment, without weakening cross-challenge isolation.

## Why this matters (production impact)
Observed on the live master before this fix:

| Symptom | Observed |
|---|---|
| AC Phala flags in the running process | `False` / `False` (env file said true) |
| AC submissions | 11, all `score=0.0`, `attested=None` |
| Raw weight snapshot for the epoch | none → `source_challenges.agent-challenge ok:false error:"missing"` |
| Sealed vector | withheld → fell back to burn `uids:[0] weights:[1.0]` |

Root cause is exactly one line of intent: `env -i "${ac_env[@]}"` wipes the ambient
environment, and the allowlist below it never included the attestation switches.
The isolation itself is correct and is **kept** — only the missing extension point is added.

## Changes
- `docker/master-entrypoint.sh`
  - New `load_challenge_env_file()` merges allowlisted `KEY=VALUE` lines into a child env array.
  - Env file per challenge, default `<data-dir>/embed.env`, overridable via
    `BASE_MASTER_AC_ENV_FILE` / `BASE_MASTER_PRISM_ENV_FILE`.
  - Applied **after** the built-in defaults, so operator values win.
  - Prefixes stay disjoint (`CHALLENGE_`/`BASE_CHALLENGE_` for AC, `PRISM_` for Prism;
    `PHALA_`, `DSTACK_`, `OPENROUTER_API_KEY` shared) so isolation is preserved.
  - Ignores comments, blanks, malformed keys and non-allowlisted keys; strips one layer
    of quotes; missing file is non-fatal; unreadable file fails loudly.
  - **Values are never logged** — key names only (secrets hygiene).
- `tests/unit/test_master_embed_env_file.py` — new behavioural coverage.

## Test plan
Tests execute the real entrypoint with a stubbed `uvicorn` that dumps its isolated
child environment, so this asserts actual runtime behaviour rather than script text.

- [x] `test_ac_env_file_supplies_phala_settings_to_isolated_child` — Phala switches + key reach AC
- [x] `test_ac_env_file_does_not_leak_into_prism_child` — isolation preserved
- [x] `test_ac_env_file_overrides_builtin_default` — file wins over defaults
- [x] `test_missing_env_file_is_not_fatal` — unchanged behaviour when absent
- [x] `test_env_file_ignores_comments_blanks_and_malformed_keys` — parser hardening

RED→GREEN verified against this PR's exact base (`origin/main` @ `a13d42a6`):

```
# pristine entrypoint from main
3 failed, 2 passed
# with this patch
5 passed
```

Regression + lint:

```
pytest tests/unit/test_master_embed_env_file.py \
       tests/unit/test_master_embed_challenges.py \
       tests/unit/test_master_embed_docs_seal.py   -> 23 passed
ruff check tests/unit/test_master_embed_env_file.py -> All checks passed
bash -n docker/master-entrypoint.sh                 -> OK
```

## CI
- Waiting for required checks to go green on this head SHA.

## Notes
- No behaviour change when no `embed.env` exists — existing deployments are unaffected.
- Does **not** weaken any fail-closed gate: attestation still has to be enabled explicitly by the operator file; this only stops the value from being discarded.
- No master `set_weights` path touched; sealer/aggregation untouched.
- Follow-up (not in this PR): restart the live master on an image containing this entrypoint, then verify both Phala flags report `True` and an attested score lands before re-enabling emissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-challenge environment configuration files.
  * Supported settings can now override built-in defaults when launching embedded challenges.
  * Configuration remains isolated between challenges, with unsupported or malformed entries ignored.
  * Missing configuration files no longer prevent challenge startup.

* **Tests**
  * Added coverage for overrides, isolation, missing files, and environment-file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->