### PR TITLE
fix(agent-challenge): resolve TB digest manifest in installed wheel

### DIFF
--- a/packages/challenges/agent-challenge/Dockerfile
+++ b/packages/challenges/agent-challenge/Dockerfile
@@ -72,6 +72,9 @@ RUN pip install --no-cache-dir --upgrade pip \
 COPY pyproject.toml README.md ./
 COPY .rules ./.rules
 COPY src ./src
+# hatch force-include maps golden/dataset-digest.json into the wheel; without
+# this COPY, ``pip install .`` fails: Forced include not found: /app/golden/...
+COPY golden/dataset-digest.json ./golden/dataset-digest.json
 # Phala Cloud pre-launch helper is measured into review/eval app-compose.
 # Offline compose generators resolve REPO_ROOT=/app (PYTHONPATH=/app/src), so
 # the shipping runtime image must package the vendor script at this exact path
@@ -126,6 +129,8 @@ RUN pip install --no-cache-dir --upgrade pip \
 COPY pyproject.toml README.md ./
 COPY .rules ./.rules
 COPY src ./src
+# Same force-include requirement as the runtime stage (see comment above).
+COPY golden/dataset-digest.json ./golden/dataset-digest.json
 
 RUN pip install --no-cache-dir .
 

--- a/packages/challenges/agent-challenge/pyproject.toml
+++ b/packages/challenges/agent-challenge/pyproject.toml
@@ -26,6 +26,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_challenge", "src/agent_challenge_runner"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"golden/dataset-digest.json" = "agent_challenge/golden/dataset-digest.json"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/packages/challenges/agent-challenge/src/agent_challenge/evaluation/own_runner_backend.py
+++ b/packages/challenges/agent-challenge/src/agent_challenge/evaluation/own_runner_backend.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import importlib.resources
 import importlib.util
 import json
 import os
@@ -963,16 +964,49 @@ def _build_default_preparer(
     return _preparer
 
 
+def _default_digest_manifest_path() -> Path:
+    """Layout-independent default for frozen ``dataset-digest.json``.
+
+    Prefer the packaged resource shipped in the wheel under
+    ``agent_challenge/golden/``; otherwise walk ancestors of this file for the
+    first existing ``golden/dataset-digest.json`` (source checkout). When nothing
+    exists, return the best candidate path so :func:`load_dataset_digest` raises
+    its normal error — never a fixed ``parents[N]``-only walk.
+    """
+    packaged_candidate: Path | None = None
+    try:
+        resource = importlib.resources.files("agent_challenge.golden").joinpath(
+            "dataset-digest.json"
+        )
+        packaged_candidate = Path(str(resource))
+        if packaged_candidate.is_file():
+            return packaged_candidate
+    except (ModuleNotFoundError, TypeError, OSError, ValueError):
+        packaged_candidate = None
+
+    here = Path(__file__).resolve()
+    fallback = packaged_candidate
+    for parent in here.parents:
+        candidate = parent / "golden" / "dataset-digest.json"
+        if candidate.is_file():
+            return candidate
+        if fallback is None and parent.name in {"agent-challenge", "agent_challenge"}:
+            fallback = candidate
+
+    if fallback is not None:
+        return fallback
+    # Last resort: first ancestor candidate (may not exist; caller raises).
+    return next(iter(here.parents)) / "golden" / "dataset-digest.json"
+
+
 def _resolve_manifest_path(path: Path | str | None) -> Path:
-    """Resolve the frozen digest-manifest path (explicit -> env -> repo default)."""
+    """Resolve the frozen digest-manifest path (explicit -> env -> packaged/repo default)."""
     if path is not None:
         return Path(path)
     env = os.environ.get(DIGEST_MANIFEST_ENV)
     if env:
         return Path(env)
-    # Repo default: ``<repo>/golden/dataset-digest.json`` relative to this file
-    # (src/agent_challenge/evaluation/own_runner_backend.py).
-    return Path(__file__).resolve().parents[3] / "golden" / "dataset-digest.json"
+    return _default_digest_manifest_path()
 
 
 def _resolve_cache_root(path: Path | str | None) -> Path:

--- a/packages/challenges/agent-challenge/src/agent_challenge/evaluation/terminal_bench.py
+++ b/packages/challenges/agent-challenge/src/agent_challenge/evaluation/terminal_bench.py
@@ -579,6 +579,10 @@ def own_runner_command_args(
         "--agent-import-path",
         settings.harbor_agent_import_path,
     ]
+    if settings.own_runner_cache_root:
+        args.extend(["--cache-root", settings.own_runner_cache_root])
+    if settings.own_runner_digest_manifest:
+        args.extend(["--digest-manifest", settings.own_runner_digest_manifest])
     if settings.harbor_model:
         args.extend(["--model", settings.harbor_model])
     return args

--- a/packages/challenges/agent-challenge/tests/test_digest_manifest_resolution.py
+++ b/packages/challenges/agent-challenge/tests/test_digest_manifest_resolution.py
@@ -167,3 +167,46 @@ def test_default_digest_not_site_packages_grandparent_shape(
             f"default resolved to site-packages overshoot path: {resolved}"
         )
     assert resolved.is_file()
+
+
+
+def test_package_dockerfile_copies_force_include_digest_before_pip_install() -> None:
+    """hatch force-include needs golden/dataset-digest.json in the image build context.
+
+    CI failed with:
+      FileNotFoundError: Forced include not found: /app/golden/dataset-digest.json
+    when Dockerfile only COPYed src/ + pyproject and then ran ``pip install .``.
+    Both runtime and terminal-bench-runner stages must COPY the file first.
+    """
+    dockerfile = (_PKG_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    pyproject = (_PKG_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"golden/dataset-digest.json"' in pyproject or (
+        "golden/dataset-digest.json" in pyproject
+    ), "pyproject must force-include golden/dataset-digest.json"
+    # Exact path used by hatch force-include source key.
+    copy_line = "COPY golden/dataset-digest.json"
+    assert copy_line in dockerfile, (
+        "Dockerfile must COPY golden/dataset-digest.json so hatch force-include "
+        "finds /app/golden/dataset-digest.json during pip install ."
+    )
+    assert dockerfile.count(copy_line) >= 2, (
+        "both runtime and terminal-bench-runner stages need the golden COPY "
+        f"(found {dockerfile.count(copy_line)})"
+    )
+    # Each pip install of the package must be preceded by the golden COPY in-file order.
+    install_marker = "RUN pip install --no-cache-dir ."
+    positions = []
+    start = 0
+    while True:
+        idx = dockerfile.find(install_marker, start)
+        if idx < 0:
+            break
+        positions.append(idx)
+        start = idx + len(install_marker)
+    assert positions, "expected at least one package pip install in Dockerfile"
+    for idx in positions:
+        preceding = dockerfile[:idx]
+        assert copy_line in preceding, (
+            "COPY golden/dataset-digest.json must appear before each "
+            "RUN pip install --no-cache-dir ."
+        )

--- a/packages/challenges/agent-challenge/tests/test_digest_manifest_resolution.py
+++ b/packages/challenges/agent-challenge/tests/test_digest_manifest_resolution.py
@@ -1,0 +1,169 @@
+"""Digest-manifest default path: precedence + installed-layout + wheel membership.
+
+The default must resolve to an existing ``dataset-digest.json`` in BOTH the
+source checkout and an installed wheel. A fixed ``Path(__file__).parents[N]``
+walk is layout-dependent and breaks under site-packages.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import subprocess
+import textwrap
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from agent_challenge.evaluation.own_runner_backend import (
+    DIGEST_MANIFEST_ENV,
+    _resolve_manifest_path,
+)
+
+_PKG_ROOT = Path(__file__).resolve().parents[1]
+_SOURCE_DIGEST = _PKG_ROOT / "golden" / "dataset-digest.json"
+_WHEEL_MEMBER_SUFFIX = "agent_challenge/golden/dataset-digest.json"
+
+
+def test_resolve_manifest_path_explicit_arg_wins_over_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given: explicit path and env both set.
+    When: resolve with the explicit path.
+    Then: returns the explicit path (not the env value).
+    """
+    explicit = tmp_path / "explicit-digest.json"
+    explicit.write_text("{}", encoding="utf-8")
+    env_path = tmp_path / "env-digest.json"
+    env_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(DIGEST_MANIFEST_ENV, str(env_path))
+
+    resolved = _resolve_manifest_path(explicit)
+
+    assert resolved == explicit
+
+
+def test_resolve_manifest_path_env_wins_over_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given: env set, no explicit path.
+    When: resolve with None.
+    Then: returns the env path (not the packaged/repo default).
+    """
+    env_path = tmp_path / "env-only-digest.json"
+    env_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv(DIGEST_MANIFEST_ENV, str(env_path))
+
+    resolved = _resolve_manifest_path(None)
+
+    assert resolved == env_path
+
+
+def test_resolve_manifest_path_default_is_existing_file_with_env_cleared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given: no explicit path and env unset.
+    When: resolve default.
+    Then: path exists on disk (source checkout or packaged resource).
+
+    A source-layout-only ``parents[3]`` check is NOT enough — that passes today
+    and would not have caught the installed-wheel bug.
+    """
+    monkeypatch.delenv(DIGEST_MANIFEST_ENV, raising=False)
+
+    resolved = _resolve_manifest_path(None)
+
+    assert resolved.is_file(), f"default digest manifest missing: {resolved}"
+    assert resolved.name == "dataset-digest.json"
+
+
+def test_resolve_manifest_path_default_not_fixed_parents3_only() -> None:
+    """Given: the resolver source.
+    When: inspected for the default branch strategy.
+    Then: must not rely solely on a bare ``parents[3]`` index (installed layout
+    drops the ``src/`` segment and overshoots into site-packages' grandparent).
+    """
+    source = textwrap.dedent(inspect.getsource(_resolve_manifest_path))
+    # Allow parents walks that search multiple ancestors; forbid the sole
+    # fixed-index default that caused the production bug.
+    tree = ast.parse(source)
+    fixed_parents3_only = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        # Match ``.parents[3]`` (Constant 3 or legacy Num)
+        slice_val: object | None = None
+        if isinstance(node.slice, ast.Constant):
+            slice_val = node.slice.value
+        if slice_val != 3:
+            continue
+        # value should be Attribute named parents
+        if isinstance(node.value, ast.Attribute) and node.value.attr == "parents":
+            fixed_parents3_only = True
+            break
+
+    assert not fixed_parents3_only, (
+        "_resolve_manifest_path still uses a fixed parents[3] default; "
+        "use importlib.resources and/or a multi-parent existence walk"
+    )
+
+
+def test_wheel_includes_dataset_digest_json(tmp_path: Path) -> None:
+    """Given: a hatch wheel build of agent-challenge.
+    When: the wheel namelist is inspected.
+    Then: member ends with agent_challenge/golden/dataset-digest.json.
+    """
+    out_dir = tmp_path / "wheel-out"
+    out_dir.mkdir()
+    repo_root = _PKG_ROOT.parents[2]  # packages/challenges/agent-challenge -> monorepo root
+    # Prefer monorepo root when present; fall back to package dir for isolated builds.
+    if not (repo_root / "pyproject.toml").is_file():
+        repo_root = _PKG_ROOT
+    env = {**os.environ, "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR", "/var/tmp/uv-cache")}
+    proc = subprocess.run(
+        [
+            "uv",
+            "build",
+            "--package",
+            "agent-challenge",
+            "--wheel",
+            "--out-dir",
+            str(out_dir),
+        ],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"uv build failed:\n{proc.stdout}\n{proc.stderr}"
+    wheels = list(out_dir.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+    names = zipfile.ZipFile(wheels[0]).namelist()
+    hits = [n for n in names if n.endswith(_WHEEL_MEMBER_SUFFIX)]
+    assert hits, (
+        f"wheel missing {_WHEEL_MEMBER_SUFFIX}; sample members: {names[:30]}"
+    )
+
+
+def test_default_digest_not_site_packages_grandparent_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given: env cleared.
+    When: default is resolved in the current layout.
+    Then: path must not look like the broken installed walk
+    ``.../pythonX.Y/golden/dataset-digest.json`` (parents[3] overshoot).
+    """
+    monkeypatch.delenv(DIGEST_MANIFEST_ENV, raising=False)
+
+    resolved = _resolve_manifest_path(None)
+    parts = resolved.parts
+    # Broken shape: .../lib/python3.12/golden/dataset-digest.json
+    if len(parts) >= 3 and parts[-2] == "golden" and parts[-1] == "dataset-digest.json":
+        parent_name = parts[-3]
+        assert not parent_name.startswith("python"), (
+            f"default resolved to site-packages overshoot path: {resolved}"
+        )
+    assert resolved.is_file()

--- a/packages/challenges/agent-challenge/tests/test_evaluation.py
+++ b/packages/challenges/agent-challenge/tests/test_evaluation.py
@@ -2332,6 +2332,77 @@ def test_own_runner_script_pip_installs_are_offline_and_hang_proofed():
     assert "--no-build-isolation" in pip_flag_line
 
 
+def test_own_runner_command_args_wires_cache_root_and_digest_manifest():
+    """In-process own_runner argv must carry broker-mounted cache/golden paths.
+
+    Parity with runner._terminal_bench_script(backend="own_runner"): without these
+    flags the spawned backend falls back to broken defaults because pydantic-settings
+    does not export CHALLENGE_* into the subprocess environment.
+    """
+    from agent_challenge.evaluation.terminal_bench import own_runner_command_args
+
+    task = BenchmarkTask(
+        task_id="terminal-bench/hello-world",
+        docker_image="example/image:latest",
+        benchmark="terminal_bench",
+        metadata={"task_id": "terminal-bench/hello-world"},
+    )
+    args = own_runner_command_args(
+        job_name="job-cache",
+        jobs_dir=Path("/tmp/jobs"),
+        job_dir=Path("/tmp/job"),
+        task=task,
+    )
+
+    assert ["--cache-root", "/opt/agent-challenge/task-cache"] == _adjacent_flag_pair(
+        args, "--cache-root"
+    )
+    assert [
+        "--digest-manifest",
+        "/opt/agent-challenge/golden/dataset-digest.json",
+    ] == _adjacent_flag_pair(args, "--digest-manifest")
+
+
+def test_own_runner_command_args_cache_wiring_honours_settings_overrides(monkeypatch):
+    from agent_challenge.evaluation.terminal_bench import own_runner_command_args
+
+    monkeypatch.setattr(
+        "agent_challenge.evaluation.terminal_bench.settings.own_runner_cache_root",
+        "/custom/cache",
+    )
+    monkeypatch.setattr(
+        "agent_challenge.evaluation.terminal_bench.settings.own_runner_digest_manifest",
+        "/custom/golden/digest.json",
+    )
+    task = BenchmarkTask(
+        task_id="terminal-bench/hello-world",
+        docker_image="example/image:latest",
+        benchmark="terminal_bench",
+        metadata={"task_id": "terminal-bench/hello-world"},
+    )
+    args = own_runner_command_args(
+        job_name="job-cache-override",
+        jobs_dir=Path("/tmp/jobs"),
+        job_dir=Path("/tmp/job"),
+        task=task,
+    )
+
+    assert ["--cache-root", "/custom/cache"] == _adjacent_flag_pair(args, "--cache-root")
+    assert ["--digest-manifest", "/custom/golden/digest.json"] == _adjacent_flag_pair(
+        args, "--digest-manifest"
+    )
+
+
+def _adjacent_flag_pair(args: list[str], flag: str) -> list[str]:
+    try:
+        index = args.index(flag)
+    except ValueError:
+        pytest.fail(f"missing flag {flag!r} in argv: {args}")
+    if index + 1 >= len(args):
+        pytest.fail(f"flag {flag!r} has no value in argv: {args}")
+    return [args[index], args[index + 1]]
+
+
 def _zip_bytes(entries: dict[str, str]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_STORED) as archive:


### PR DESCRIPTION
## Summary
- Every Terminal-Bench trial was failing instantly at `failure_stage: job` with `TaskDefNotFoundError: digest manifest missing: /usr/local/lib/python3.12/golden/dataset-digest.json` (`reason_code=terminal_bench_failed`).
- The miner's agent never loaded, so every submission scored **0/30** regardless of quality (confirmed on two independent hotkeys).
- This PR closes the three compounding defects that caused the miss so TB trials can resolve the digest manifest from an installed wheel and pass cache paths into the own-runner subprocess.

## Symptom
```
TaskDefNotFoundError: digest manifest missing: /usr/local/lib/python3.12/golden/dataset-digest.json
reason_code=terminal_bench_failed
failure_stage: job
```
Production path never reached agent load; score was always 0/30.

## Root cause (three defects)
1. **CLI parity gap** — `terminal_bench.own_runner_command_args` did not pass `--cache-root` / `--digest-manifest`, while the equivalent builder in `runner.py` (~L1964–1967) already did. The production TB attempt path uses the former.
2. **Layout-unsafe default** — `_resolve_manifest_path` fell back to `Path(__file__).resolve().parents[3] / "golden" / "dataset-digest.json"`, correct only for the `src/` checkout layout; in an installed wheel it overshoots into `site-packages`' grandparent (`/usr/local/lib/python3.12/golden/...`).
3. **Missing package data** — `golden/dataset-digest.json` was never shipped as wheel package data.

**Why flags matter:** pydantic-settings reads `embed.env` into the settings object but does **not** export to `os.environ`, so the spawned runner subprocess never inherited the correct paths. Passing them explicitly as CLI flags is the durable bridge.

## Changes
- `own_runner_command_args`: forward `--cache-root` and `--digest-manifest` (parity with `runner.py`).
- `_resolve_manifest_path`: layout-safe default that works for both checkout and installed wheel.
- `pyproject.toml`: ship `golden/dataset-digest.json` as package data so the wheel contains `agent_challenge/golden/dataset-digest.json`.
- Tests covering flag emission and installed-layout / wheel resolution.

## Test plan
- [x] Local: `own_runner or terminal_bench` selection — **672 passed / 3 skipped**
- [x] Local: ruff clean on touched packages
- [x] Local: wheel proven to contain `agent_challenge/golden/dataset-digest.json`
- [x] Local: installed-venv default resolution proven
- [ ] CI: required checks green on this head SHA

## Prod mitigation note
A **temporary symlink mitigation is currently live in production** and will be **removed after this deploys**. This PR is the durable fix; do not leave the symlink as the long-term path.

## CI
- Waiting for required checks to go green on this head SHA.

## Notes
- Commits (do not rewrite): `6bfd68af`, `98e55aeb`
- No deployment config / `compose.env` changes
- Not merging from this PR flow — merge decision is manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the digest manifest is located, working correctly in both installed (wheel) and source checkout layouts.
  * Kept support for explicitly provided and environment-specified digest manifest paths.
  * Runner commands now correctly include configured cache and digest manifest settings.

* **Reliability**
  * Ensured the dataset digest manifest is bundled into built packages and included in Docker images for consistent evaluation runs.

* **Tests**
  * Added coverage to prevent regressions in manifest resolution and runner argument wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->