### PR TITLE
fix(agent-challenge): supply LLM_MODEL to the evaluated agent

### DIFF
--- a/packages/challenges/agent-challenge/src/agent_challenge/evaluation/own_runner/isolation.py
+++ b/packages/challenges/agent-challenge/src/agent_challenge/evaluation/own_runner/isolation.py
@@ -66,6 +66,9 @@ __all__ = [
 AGENT_ENV_ALLOWLIST: frozenset[str] = frozenset(
     {
         "LLM_COST_LIMIT",
+        # VAL-LLM-MODEL: the packaged agent fails closed without a concrete
+        # model id ("set LLM_MODEL"). Not secret-shaped, never a URL/host.
+        "LLM_MODEL",
         "OPENROUTER_API_KEY",
     }
 )

--- a/packages/challenges/agent-challenge/src/agent_challenge/evaluation/runner.py
+++ b/packages/challenges/agent-challenge/src/agent_challenge/evaluation/runner.py
@@ -1631,6 +1631,14 @@ def _terminal_bench_env(
         "BASE_BENCHMARK_DATASET": settings.terminal_bench_dataset,
         **TERMINAL_BENCH_WRITABLE_ENV,
     }
+    # VAL-LLM-MODEL: the packaged agent fails closed without a concrete model id
+    # ("A concrete model id is required: set LLM_MODEL"). The platform holds it
+    # as CHALLENGE_LLM_MODEL, which the agent never reads, so publish it under
+    # the name the agent expects. A miner-supplied LLM_MODEL overrides this in
+    # the sanitized merge below. Left unset when the operator blanks it, so the
+    # agent still fails loudly rather than running an unmeasured default.
+    if settings.llm_model:
+        env["LLM_MODEL"] = settings.llm_model
     for name in settings.harbor_forward_env_vars:
         value = os.environ.get(name)
         if value and name not in TERMINAL_BENCH_CONTROL_ENV_KEYS:

--- a/packages/challenges/agent-challenge/src/agent_challenge/submissions/miner_env.py
+++ b/packages/challenges/agent-challenge/src/agent_challenge/submissions/miner_env.py
@@ -46,6 +46,10 @@ MINER_ENV_PRODUCT_ALLOWLIST: Final[frozenset[str]] = frozenset(
     {
         "OPENROUTER_API_KEY",
         "LLM_COST_LIMIT",
+        # VAL-LLM-MODEL: a miner may bring their own key *and* their own model
+        # id. Not a URL/host/proxy name, and URL-shaped values stay rejected by
+        # ``looks_like_url_value``, so this opens no endpoint-injection hole.
+        "LLM_MODEL",
         "EVAL_RUN_TOKEN",
         "REVIEW_SESSION_TOKEN",
     }

--- a/packages/challenges/agent-challenge/tests/test_deepseek_via_gateway.py
+++ b/packages/challenges/agent-challenge/tests/test_deepseek_via_gateway.py
@@ -173,7 +173,14 @@ async def test_deepseek_no_longer_routes_through_master_gateway(
     assert "BASE_LLM_GATEWAY_URL" not in env
     assert "BASE_GATEWAY_TOKEN" not in env
     assert "DEEPSEEK_API_KEY" not in env
-    assert "LLM_MODEL" not in env
+    # VAL-LLM-MODEL: LLM_MODEL is no longer gateway-derived. It is supplied
+    # from measured platform settings because the packaged agent fails closed
+    # without a concrete model id, so its presence is NOT gateway injection.
+    # Assert it carries the settings value and that nothing from the residual
+    # gateway (base_url / token) leaks into the job env.
+    assert env.get("LLM_MODEL") == "x-ai/grok-4.5"
+    assert "master-gateway.test" not in str(env)
+    assert "scoped-assignment-token" not in str(env)
     serialized = json.dumps(env, sort_keys=True)
     assert "api.deepseek.com" not in serialized
 

--- a/packages/challenges/agent-challenge/tests/test_llm_model_reaches_agent.py
+++ b/packages/challenges/agent-challenge/tests/test_llm_model_reaches_agent.py
@@ -1,0 +1,78 @@
+"""The LLM model id must reach the agent (VAL-LLM-MODEL).
+
+The packaged agent fails closed when ``LLM_MODEL`` is unset::
+
+    agent run failed: A concrete model id is required: set LLM_MODEL
+    (the measured review harness supplies it under .rules).
+
+Three independent layers dropped it, so *every* evaluation scored 0 and every
+``result.json`` carried ``"model_name": null``:
+
+1. the runner never set ``LLM_MODEL`` -- the platform only holds
+   ``CHALLENGE_LLM_MODEL`` (settings ``llm_model``), which the agent never reads;
+2. :func:`sanitize_miner_env_for_job` stripped a miner-supplied ``LLM_MODEL``
+   because the name is not token/key shaped;
+3. :data:`AGENT_ENV_ALLOWLIST` admitted only ``LLM_COST_LIMIT`` and
+   ``OPENROUTER_API_KEY``.
+
+A miner may bring their own key *and* their own model; when they supply neither,
+the measured platform model is used.
+"""
+
+from __future__ import annotations
+
+from agent_challenge.core.config import settings
+from agent_challenge.evaluation.own_runner.isolation import (
+    AGENT_ENV_ALLOWLIST,
+    filter_agent_env,
+)
+from agent_challenge.evaluation.runner import _terminal_bench_env
+from agent_challenge.submissions.miner_env import (
+    sanitize_miner_env_for_job,
+    validate_miner_env,
+)
+
+
+def test_agent_env_allowlist_admits_llm_model() -> None:
+    """Layer 3: the agent sandbox must be allowed to see the model id."""
+    assert "LLM_MODEL" in AGENT_ENV_ALLOWLIST
+
+
+def test_filter_agent_env_keeps_llm_model() -> None:
+    """Layer 3: the final filter must not strip the model id."""
+    kept = filter_agent_env({"LLM_MODEL": "x-ai/grok-4.5", "OPENROUTER_API_KEY": "sk-or-x"})
+    assert kept["LLM_MODEL"] == "x-ai/grok-4.5"
+    assert kept["OPENROUTER_API_KEY"] == "sk-or-x"
+
+
+def test_runner_injects_platform_llm_model() -> None:
+    """Layer 1: with no miner env, the measured platform model is supplied."""
+    env = _terminal_bench_env()
+    assert env["LLM_MODEL"] == settings.llm_model
+    assert env["LLM_MODEL"], "platform model id must not be empty"
+
+
+def test_miner_may_supply_own_llm_model() -> None:
+    """Layer 2: a miner bringing their own key may also choose their model."""
+    assert sanitize_miner_env_for_job({"LLM_MODEL": "openai/gpt-5"}) == {
+        "LLM_MODEL": "openai/gpt-5"
+    }
+    assert validate_miner_env({"LLM_MODEL": "openai/gpt-5"}) == {"LLM_MODEL": "openai/gpt-5"}
+
+
+def test_miner_llm_model_overrides_platform_default() -> None:
+    """A miner-supplied model wins over the platform default."""
+    env = _terminal_bench_env({"LLM_MODEL": "openai/gpt-5"})
+    assert env["LLM_MODEL"] == "openai/gpt-5"
+
+
+def test_llm_model_value_must_not_be_a_url() -> None:
+    """Admitting the name must not open an endpoint-injection hole."""
+    assert sanitize_miner_env_for_job({"LLM_MODEL": "http://evil.example/v1"}) == {}
+
+
+def test_llm_model_is_not_treated_as_a_secret() -> None:
+    """The model id is not secret-shaped, so it must not be flagged as one."""
+    from agent_challenge.evaluation.own_runner.isolation import disallowed_secret_keys
+
+    assert "LLM_MODEL" not in disallowed_secret_keys({"LLM_MODEL": "x-ai/grok-4.5"})

--- a/packages/challenges/agent-challenge/tests/test_miner_env_lock.py
+++ b/packages/challenges/agent-challenge/tests/test_miner_env_lock.py
@@ -163,8 +163,13 @@ def test_terminal_bench_env_ignores_miner_base_log_stream_override() -> None:
 # --------------------------------------------------------------------------- #
 # VAL-ACLOCK-005 / 006 — agent sandbox allowlist + chokepoint
 # --------------------------------------------------------------------------- #
-def test_agent_env_allowlist_exactly_or_key_and_cost_limit() -> None:
-    assert AGENT_ENV_ALLOWLIST == frozenset({"OPENROUTER_API_KEY", "LLM_COST_LIMIT"})
+def test_agent_env_allowlist_exactly_key_cost_limit_and_model() -> None:
+    # VAL-LLM-MODEL: LLM_MODEL joins the sandbox allowlist because the packaged
+    # agent fails closed without a concrete model id. The exact pin is
+    # deliberate: nothing else enters this set without an explicit decision.
+    assert AGENT_ENV_ALLOWLIST == frozenset(
+        {"OPENROUTER_API_KEY", "LLM_COST_LIMIT", "LLM_MODEL"}
+    )
 
 
 def test_filter_agent_env_strips_url_proxy_and_extra_secrets() -> None:

--- a/packages/challenges/agent-challenge/tests/test_own_runner_isolation.py
+++ b/packages/challenges/agent-challenge/tests/test_own_runner_isolation.py
@@ -108,7 +108,12 @@ def test_allowlist_excludes_base_gateway_vars() -> None:
     assert "BASE_LLM_GATEWAY_URL" not in AGENT_ENV_ALLOWLIST
     assert "BASE_GATEWAY_TOKEN" not in AGENT_ENV_ALLOWLIST
     assert "LLM_COST_LIMIT" in AGENT_ENV_ALLOWLIST
-    assert AGENT_ENV_ALLOWLIST == frozenset({"LLM_COST_LIMIT", "OPENROUTER_API_KEY"})
+    # VAL-LLM-MODEL: the packaged agent fails closed without a concrete model
+    # id, so LLM_MODEL is admitted alongside the key and cost limit. The
+    # gateway/URL/host/proxy exclusions above remain the invariant.
+    assert AGENT_ENV_ALLOWLIST == frozenset(
+        {"LLM_COST_LIMIT", "LLM_MODEL", "OPENROUTER_API_KEY"}
+    )
 
 
 def test_harness_control_keys_are_not_secrets() -> None:

--- a/packages/challenges/agent-challenge/tests/test_worker_security.py
+++ b/packages/challenges/agent-challenge/tests/test_worker_security.py
@@ -195,10 +195,14 @@ async def test_worker_broker_path_scrubs_token_and_signature_metadata_and_keeps_
         "hello-world",
     ]
     benchmark_spec = executor.specs[1]
+    # VAL-LLM-MODEL: the measured model id now ships in the job env (the packaged
+    # agent fails closed without a concrete LLM_MODEL). It is a plain model name,
+    # not a secret -- the assert_no_untrusted_secret guards below still apply.
     assert benchmark_spec.env == {
         "BASE_AGENT_PATH": "/workspace/agent",
         "BASE_BENCHMARK_DATASET": "terminal-bench/terminal-bench-2-1",
         "HOME": "/tmp",
+        "LLM_MODEL": "x-ai/grok-4.5",
         "XDG_CACHE_HOME": "/tmp/.cache",
     }
     assert_no_untrusted_secret(


### PR DESCRIPTION
## Problem

Every Terminal-Bench evaluation scored **0/30** and every `result.json` carried `"model_name": null`. The packaged agent fails closed without a concrete model id:

```
agent run failed: A concrete model id is required: set LLM_MODEL
(the measured review harness supplies it under .rules). No default model is assumed.
```

This error never reached the database — it is written to `exception.txt` inside the trial dir, while the job log events are truncated at 16 KB. Diagnosed by running `own_runner_backend` by hand on the prod validator with the app's own environment.

## Root cause — three independent layers

| # | Layer | Behaviour |
|---|-------|-----------|
| 1 | `_terminal_bench_env` | never set `LLM_MODEL`; the platform only holds `CHALLENGE_LLM_MODEL` (`settings.llm_model`), which the agent never reads |
| 2 | `sanitize_miner_env_for_job` | stripped a miner-supplied `LLM_MODEL` — the name is not token/key shaped |
| 3 | `AGENT_ENV_ALLOWLIST` | admitted only `LLM_COST_LIMIT` and `OPENROUTER_API_KEY` |

Empirically confirmed:

```
miner sends : ['BASEAGENT_MODEL', 'LLM_COST_LIMIT', 'LLM_MODEL', 'OPENROUTER_API_KEY']
survives    : ['LLM_COST_LIMIT', 'OPENROUTER_API_KEY']
```

`OPENROUTER_API_KEY` was reaching the agent correctly the whole time — only the model id was missing, so each trial died in ~5 s before any LLM call. It was structurally impossible for any submission to score.

## Fix

- `_terminal_bench_env` publishes `settings.llm_model` as `LLM_MODEL`, **before** the sanitized miner merge so a miner can override it.
- `LLM_MODEL` joins `MINER_ENV_PRODUCT_ALLOWLIST` — a miner may bring their own key **and** their own model.
- `LLM_MODEL` joins `AGENT_ENV_ALLOWLIST` so it survives `filter_agent_env`.
- When an operator blanks `llm_model`, nothing is injected: the agent still fails loudly rather than running an unmeasured default.

## Security invariants preserved

- URL-shaped values are still rejected, so admitting the name opens no endpoint-injection hole.
- Gateway / URL / host / proxy names remain excluded from both allowlists.
- `assert_no_untrusted_secret` guards untouched; `LLM_MODEL` is not secret-shaped.
- The ex-gateway test now asserts `LLM_MODEL` comes from settings **and** that no gateway `base_url` / token leaks — stronger than the previous blanket ban, which only existed because the gateway used to be its sole source.

## Verification

- 7 new tests: **RED → GREEN**.
- Full `agent-challenge` suite: **zero regressions** — 26 pre-existing failures on `main`, 26 with this change, identical sets; passing 2286 → 2293.
- On the prod validator, injecting `LLM_MODEL` at runtime moved the trial from dying in 5 s to running task containers for minutes (`alexgshaw-cancel-async-tasks-...-tmux` up 2 and 8 minutes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent executions now receive the configured language model identifier through `LLM_MODEL`.
  * Miners can provide a valid model identifier to override the platform default.
* **Security**
  * Model identifiers are allowed while gateway URLs, tokens, and URL-shaped values continue to be excluded.
* **Tests**
  * Added coverage for model propagation, overrides, validation, isolation, and sensitive gateway-data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->